### PR TITLE
fix Transient Blossom ICD reset timing

### DIFF
--- a/internal/characters/albedo/albedo.go
+++ b/internal/characters/albedo/albedo.go
@@ -190,9 +190,6 @@ func (c *char) Skill(p map[string]int) (int, int) {
 	c.skillAttackInfo = ai
 	c.skillSnapshot = c.Snapshot(&c.skillAttackInfo)
 
-	// Reset ICD
-	c.icdSkill = c.Core.F - 1
-
 	//create a construct
 	// Construct is not fully formed until after the hit lands (exact timing unknown)
 	c.AddTask(func() {
@@ -201,6 +198,10 @@ func (c *char) Skill(p map[string]int) (int, int) {
 		c.lastConstruct = c.Core.F
 
 		c.Tags["elevator"] = 1
+
+		// Reset ICD when the new construct is created
+		c.icdSkill = c.Core.F - 1
+
 	}, "albedo-create-construct", f)
 
 	c.SetCD(core.ActionSkill, 240)


### PR DESCRIPTION
old: Transient Blossom ICD resets after using E
new: Transient Blossom ICD resets after construct has been created (which reflects what really happens). source: https://discord.com/channels/763583452762734592/763610791839924224/1001895536552595536